### PR TITLE
Allow loading Open Sans fonts over https

### DIFF
--- a/_site/css/app.css
+++ b/_site/css/app.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
+@import url(//fonts.googleapis.com/css?family=Open+Sans);
 
 body,html{
     margin: 0;


### PR DESCRIPTION
Changing the import url to use `//` which will load via either http or https depending on the page url. See: http://stackoverflow.com/questions/4659345/is-there-any-downside-for-using-a-leading-double-slash-to-inherit-the-protocol-i
