### PR TITLE
Update examples code so they're not using deprecated property.

### DIFF
--- a/required/examples/basics/text.js
+++ b/required/examples/basics/text.js
@@ -11,7 +11,10 @@ basicText.y = 90;
 stage.addChild(basicText);
 
 var style = {
-    font : 'bold italic 36px Arial',
+    fontFamily : 'Arial',
+    fontSize : '36px',
+    fontStyle : 'italic',
+    fontWeight : 'bold',
     fill : '#F7EDCA',
     stroke : '#4a1850',
     strokeThickness : 5,

--- a/required/examples/demos/masking.js
+++ b/required/examples/demos/masking.js
@@ -73,7 +73,7 @@ function onClick()
     }
 }
 
-var help = new PIXI.Text('Click to turn masking on / off.', { font:'bold 12pt Arial', fill: 'white' });
+var help = new PIXI.Text('Click to turn masking on / off.', { fontFamily:'Arial', fontSize:'12pt', fontWeight:'bold', fill: 'white' });
 help.position.y = renderer.height - 26;
 help.position.x = 10;
 stage.addChild(help);

--- a/required/examples/demos/texture-rotate.js
+++ b/required/examples/demos/texture-rotate.js
@@ -52,7 +52,7 @@ function init() {
         dude.position.x = offsetX + gridW * (i % 4);
         dude.position.y = offsetY + gridH * (i / 4 | 0);
         stage.addChild(dude);
-        var text = new PIXI.Text("rotate = "+dude.texture.rotate, { font: '12px Courier New', fill: 'white', align: 'left' });
+        var text = new PIXI.Text("rotate = "+dude.texture.rotate, { fontFamily:'Courier New', fontSize:'12px', fill: 'white', align: 'left' });
         text.position.x = dude.position.x;
         text.position.y = dude.position.y - 20;
         stage.addChild(text);

--- a/required/examples/demos/video.js
+++ b/required/examples/demos/video.js
@@ -23,7 +23,7 @@ moveSprite.position.y = renderer.height / 2;
 
 stage.addChild(moveSprite);
 
-var text = new PIXI.Text('DEUS', {fill:'white', font:'bold 444px Arial'});
+var text = new PIXI.Text('DEUS', {fill:'white', fontFamily:'Arial', fontSize:'444px', fontWeight:'bold'});
 //stage.addChild(text);
 
 text.anchor.set(0.5);

--- a/required/examples/filters/filter.js
+++ b/required/examples/filters/filter.js
@@ -60,7 +60,7 @@ function onClick()
     }
 }
 
-var help = new PIXI.Text('Click to turn filters on / off.', { font: 'bold 12pt Arial', fill: 'white' });
+var help = new PIXI.Text('Click to turn filters on / off.', { fontFamily:'Arial', fontSize:'12pt', fontWeight:'bold', fill: 'white' });
 help.position.y = renderer.height - 25;
 help.position.x = 10;
 


### PR DESCRIPTION
Currently the examples are still using `font` property (which is deprecated in V4). Updating them by using new properties.
