### PR TITLE
Add more embed options

### DIFF
--- a/dest/css/pixi-examples.min.css
+++ b/dest/css/pixi-examples.min.css
@@ -625,6 +625,10 @@ a:hover {
   transition: left 0.2s cubic-bezier(0.215, 0.61, 0.355, 1);
   -webkit-overflow-scrolling: touch;
 }
+.main-content .main-tabs,
+.main-content .redirect {
+  display: none;
+}
 .main-content .example-frame {
   width: 100%;
   max-width: 800px;
@@ -784,7 +788,7 @@ a:hover {
   height: auto;
   overflow-y: hidden;
   overflow-x: auto;
-  margin: 0px;
+  margin: 0 0 -30px 0;
 }
 .main-content .code .footer {
   background: #38404e;
@@ -898,31 +902,118 @@ a:hover {
 .main-content .submit a:hover {
   color: #ec407a;
 }
-.main-content-lite {
-  left: 0px;
-  bottom: auto;
-  top: 0;
-  height: fit-content;
-  padding: 0;
-}
-.main-content-lite .reload {
-  margin-top: -128px;
-}
-.main-content-lite a.to-editor {
-  position: absolute;
-  right: 12px;
-  top: 12px;
-}
-.main-content-lite a.to-editor img {
-  width: 24px;
-  height: 24px;
-}
 body {
   font-family: 'Roboto', sans-serif;
   font-weight: 400;
   font-size: 13px;
   line-height: 19px;
   color: #919bac;
+  background-color: #272d37;
+}
+body.embed {
+  background-color: black;
+}
+body.embed .main-content {
+  overflow: hidden;
+  left: 0px;
+  bottom: auto;
+  top: 0;
+  height: 100%;
+  padding: 0;
+  background: transparent;
+}
+body.embed .main-content .example-frame {
+  max-width: none;
+  top: 50%;
+  transform: translateY(-50%);
+}
+body.embed .main-content .main-tabs {
+  display: block;
+  position: fixed;
+  top: 2px;
+  left: 2px;
+  z-index: 1;
+}
+body.embed .main-content .main-tabs .main-tab {
+  background: #272d37;
+  color: #f06292;
+  height: 35px;
+  line-height: 0;
+  font-size: 14px;
+  font-weight: bold;
+  padding: 0 15px;
+  border: 0;
+  appearance: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  outline: none;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+body.embed .main-content .main-tabs .main-tab.selected {
+  border-color: #f06292;
+}
+body.embed .main-content .main-tabs .main-tab:hover {
+  color: #d81b60;
+}
+body.embed .main-content .reload {
+  margin-top: -32px;
+  top: 50%;
+}
+body.embed .main-content .redirect {
+  position: fixed;
+  display: block;
+  top: 2px;
+  right: 2px;
+  z-index: 1;
+  background: #272d37;
+  width: 45px;
+  height: 35px;
+  transition: opacity 0.3s;
+}
+body.embed .main-content .redirect img {
+  margin: 6px 0 0 14px;
+  width: 20px;
+  height: 20px;
+}
+body.embed .main-content .redirect:hover img {
+  opacity: 0.8;
+}
+body.embed .content-controls {
+  width: 100%;
+  position: fixed;
+  top: 40px;
+  left: 0;
+  bottom: 0;
+  overflow-y: auto;
+}
+body.embed .content-controls .code {
+  max-width: none;
+  margin-top: 0;
+  border: 0;
+}
+body.embed .content-controls .code > .CodeMirror {
+  font-size: 13px;
+}
+body.embed .content-controls .submit,
+body.embed .content-controls .footer {
+  display: none;
+}
+body.embed #example-title,
+body.embed .main-header,
+body.embed .main-nav,
+body.embed .code-header,
+body.embed.nocode .content-controls,
+body.embed.nocode .main-tabs,
+body.embed.autoplay .reload,
+body.embed.noredirect .redirect {
+  display: none;
+}
+body.embed.view-code .example-frame,
+body.embed.view-preview .content-controls {
+  opacity: 0;
+  pointer-events: none;
+  height: 1px;
+  overflow: hidden;
 }
 h1 {
   font-weight: 400;
@@ -1133,12 +1224,12 @@ h1 {
     height: 30px;
     margin: -13px 0 0 -13px;
   }
-  .main-content-lite {
+  body.embed .main-content {
     left: 0px;
     padding: 0;
   }
-  .main-content-lite .example-frame .reload {
-    margin-top: -128px;
+  body.embed .main-content .example-frame .reload {
+    margin-top: -40px;
   }
   h1 {
     font-size: 32px;
@@ -1150,7 +1241,7 @@ h1 {
   .main-content .code .footer {
     text-align: left;
   }
-  .main-content-lite {
+  body.embed .main-content {
     left: 0px;
   }
 }
@@ -1163,7 +1254,7 @@ h1 {
   background-color: #647086;
   border-radius: 4px;
 }
-#code-header > a {
+.code-header > a {
   color: #919bac;
   text-decoration: underline;
 }

--- a/dest/js/pixi-examples.min.js
+++ b/dest/js/pixi-examples.min.js
@@ -13,6 +13,11 @@ function getMajorPixiVersion(pixiVersionString) {
     return majorVersion;
 }
 
+function reload() {
+    if (bpc.editor) bpc.exampleSourceCode = bpc.editor.getValue();
+    bpc.generateIFrameContent();
+}
+
 jQuery(document).ready($ => {
     window.onpopstate = function onpopstate(event) {
         bpc.pixiVersionString = getParameterByName("v") || "dev";
@@ -44,7 +49,7 @@ jQuery(document).ready($ => {
     };
     bpc.clickType = "click";
     bpc.animTime = .15;
-    bpc.liteMode = false;
+    bpc.autoPlay = true;
     bpc.packagesManifest = {};
     bpc.resize = function resize() {};
     bpc.scriptsToLoad = [ "https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenMax.min.js" ];
@@ -112,15 +117,41 @@ jQuery(document).ready($ => {
     };
     bpc.initNav = function initNav() {
         if (typeof URLSearchParams !== "undefined") {
-            const params = new URLSearchParams(window.location.search);
-            if (params.get("lite") === "true") {
-                $("#example-title").addClass("hidden");
-                $(".main-header").addClass("hidden");
-                $(".main-nav").addClass("hidden");
-                $(".main-content").addClass("main-content-lite");
-                $("#content-controls").addClass("hidden");
-                $(".main-content").append(`<a class="to-editor" rel="noopener noreferrer" target="_blank" href="${window.location.href.replace("lite=true", "")}">` + '<img src="examples/assets/external-link-ltr-icon.svg"></img>' + "</a>");
-                bpc.liteMode = true;
+            const search = window.location.search;
+            const params = new URLSearchParams(search);
+            if (params.get("lite") || params.get("embed")) {
+                const $body = $("body");
+                const $reload = $(".reload");
+                $body.addClass("embed");
+                $("#redirect").attr("href", window.location.href.replace(search, ""));
+                bpc.autoPlay = !!params.get("autoplay");
+                if (bpc.autoPlay) {
+                    $body.addClass("autoplay");
+                } else {
+                    $reload.on(bpc.clickType, (function onClick() {
+                        $(this).addClass("hidden");
+                    }));
+                }
+                if (params.get("noredirect")) {
+                    $body.addClass("noredirect");
+                }
+                const showcode = params.get("showcode");
+                if (!showcode) {
+                    $body.addClass("nocode");
+                } else {
+                    const $tabs = $(".main-tab");
+                    $body.addClass($tabs.filter(".selected").data("view"));
+                    $tabs.on(bpc.clickType, (function onClick() {
+                        $tabs.removeClass("selected");
+                        $(this).addClass("selected");
+                        $tabs.each((function onEach() {
+                            $body.removeClass(this.dataset.view);
+                        }));
+                        $body.addClass(this.dataset.view);
+                        $reload.addClass("hidden");
+                        reload();
+                    }));
+                }
             }
         }
         $(".main-menu .section").on(bpc.clickType, (function onClick() {
@@ -160,7 +191,9 @@ jQuery(document).ready($ => {
         bpc.loadPackages = function loadPackages() {
             $.getJSON("examples/packages.json", data => {
                 bpc.packagesManifest = data;
-                if (!bpc.liteMode) bpc.generateIFrameContent();
+                if (bpc.autoPlay) {
+                    bpc.generateIFrameContent();
+                }
             });
         };
         bpc.generateIFrameContent = function generateIFrameContent() {
@@ -334,10 +367,7 @@ jQuery(document).ready($ => {
         $(".footer .download").on(bpc.clickType, () => {
             bpc.SaveToDisk(bpc.exampleUrl, bpc.exampleFilename);
         });
-        $(".reload").on(bpc.clickType, () => {
-            if (bpc.editor) bpc.exampleSourceCode = bpc.editor.getValue();
-            bpc.generateIFrameContent();
-        });
+        $(".reload").on(bpc.clickType, reload);
     };
     bpc.SaveToDisk = function SaveToDisk(fileURL, fileName) {
         if (!window.ActiveXObject) {

--- a/examples/assets/external-link-ltr-icon.svg
+++ b/examples/assets/external-link-ltr-icon.svg
@@ -1,6 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
-	<path fill="#272d3" stroke="#ec407a" d="M1.5 4.518h5.982V10.5H1.5z"/>
-	<path fill="#272d3" d="M5.765 1H11v5.39L9.427 7.937l-1.31-1.31L5.393 9.35l-2.69-2.688 2.81-2.808L4.2 2.544z"/>
-	<path fill="#ec407a" d="M9.995 2.004l.022 4.885L8.2 5.07 5.32 7.95 4.09 6.723l2.882-2.88-1.85-1.852z"/>
-</svg>
+<svg enable-background="new 0 0 12 12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="m2 10h5v-2.2l-1.6 1.5-2.7-2.6 1.6-1.7h-2.3z" fill="none"/><g fill="#ec407a"><path d="m7 10h-5v-5h2.3l1-1h-4.3v7h7v-4.2l-1 1z"/><path d="m5.1 2 1.9 1.8-2.9 2.9 1.2 1.3 2.9-2.9 1.8 1.8v-4.9z"/></g></svg>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,13 @@
         </div>
     </nav>
     <article class="main-content">
+        <a id="redirect" class="redirect" rel="noopener noreferrer" target="_blank" href="#">
+            <img src="examples/assets/external-link-ltr-icon.svg" />
+        </a>
+        <div class="main-tabs">
+            <button class="main-tab selected" data-view="view-preview">Canvas</button>
+            <button class="main-tab" data-view="view-code">Code</button>
+        </div>
         <h1 id="example-title">Loading&hellip;</h1>
         <div class="example-frame">
             <div class="sizer" id="example">
@@ -63,9 +70,9 @@
                 </svg>
             </div>
         </div>
-        <div id="content-controls">
+        <div class="content-controls">
             <div class="code clearfix">
-                <h3 id="code-header">Example Code</h3>
+                <h3 class="code-header" id="code-header">Example Code</h3>
                 <textarea id="code"></textarea>
                 <div class="footer">
                     <div class="select-group">

--- a/src/less/768up.less
+++ b/src/less/768up.less
@@ -41,14 +41,13 @@
 	}
 }
 
-.main-content-lite {
+body.embed .main-content {
 	left: 0px;
 	padding: 0;
 
 	.example-frame {
-
 		.reload {
-			margin-top: -128px;
+			margin-top: -40px;
 		}
 	}
 }

--- a/src/less/980up.less
+++ b/src/less/980up.less
@@ -6,6 +6,6 @@
 	}
 }
 
-.main-content-lite {
+body.embed .main-content {
 	left: 0px;
 }

--- a/src/less/base.less
+++ b/src/less/base.less
@@ -216,6 +216,10 @@ a {
 	.transition(left, @anim);
 	-webkit-overflow-scrolling: touch;
 
+    .main-tabs,
+    .redirect {
+        display: none;
+    }
 	.example-frame {
 		width: 100%;
 		max-width: 800px;
@@ -374,7 +378,7 @@ a {
 			height: auto;
 			overflow-y: hidden;
 			overflow-x: auto;
-			margin: 0px;
+			margin: 0 0 -30px 0;
 		}
 
 		.footer {
@@ -492,29 +496,6 @@ a {
 	}
 }
 
-.main-content-lite {
-	left: 0px;
-	bottom: auto;
-	top: 0;
-	height: fit-content;
-	padding: 0;
-
-	.reload {
-		margin-top: -128px;
-	}
-
-	a.to-editor {
-		position: absolute;
-		right: 12px;
-		top: 12px;
-
-		img {
-			width: 24px;
-			height: 24px;
-		}
-	}
-}
-
 // Typography
 body {
 	font-family: 'Roboto', sans-serif;
@@ -522,6 +503,117 @@ body {
 	font-size: 13px;
 	line-height: 19px;
 	color: @blue300;
+    background-color: #272d37;
+}
+
+body.embed  {
+    background-color: black;
+    .main-content {
+        overflow: hidden;
+        left: 0px;
+        bottom: auto;
+        top: 0;
+        height: 100%;
+        padding: 0;
+        background: transparent;
+        .example-frame {
+            max-width: none;
+            top: 50%;
+            transform: translateY(-50%);
+        }
+
+        .main-tabs {
+            display: block;
+            position: fixed;
+            top: 2px;
+            left: 2px;
+            z-index: 1;
+            .main-tab {
+                background: @blue900;
+                color: @pink300;
+                height: 35px;
+                line-height: 0;
+                font-size: 14px;
+                font-weight: bold;
+                padding: 0 15px;
+                border: 0;
+                appearance: none;
+                border-bottom: 2px solid transparent;
+                cursor: pointer;
+                outline: none;
+                transition: background-color 0.3s, border-color 0.3s;
+                &.selected {
+                    border-color: @pink300;
+                }
+                &:hover {
+                    color: @pink600;
+                }
+            }
+        }
+        .reload {
+            margin-top: -32px;
+            top: 50%;
+        }
+
+        .redirect {
+            position: fixed;
+            display: block;
+            top: 2px;
+            right: 2px;
+            z-index: 1;
+            background: @blue900;
+            width: 45px;
+            height: 35px;
+            img {
+                margin: 6px 0 0 14px;
+                width: 20px;
+                height: 20px;
+            }
+            transition: opacity 0.3s;
+            &:hover img {
+                opacity: 0.8;
+            }
+        }
+    }
+
+    .content-controls {
+        width: 100%;
+        position: fixed;
+        top: 40px;
+        left: 0;
+        bottom: 0;
+        overflow-y: auto;
+        .code {
+            max-width: none;
+            margin-top: 0;
+            border: 0;
+            & > .CodeMirror {
+                font-size: 13px;
+            }
+        }
+        .submit, .footer {
+            display: none;
+        }
+    }
+
+    #example-title,
+    .main-header,
+    .main-nav,
+    .code-header,
+    &.nocode .content-controls,
+    &.nocode .main-tabs,
+    &.autoplay .reload,
+    &.noredirect .redirect {
+        display: none;
+    }
+
+    &.view-code .example-frame,
+    &.view-preview .content-controls {
+        opacity: 0;
+        pointer-events: none;
+        height: 1px;
+        overflow: hidden;
+    }
 }
 
 h1 {

--- a/src/less/pixi-examples.less
+++ b/src/less/pixi-examples.less
@@ -21,7 +21,7 @@
     border-radius: 4px;
 }
 
-#code-header > a {
+.code-header > a {
     color: #919bac;
     text-decoration: underline;
 }


### PR DESCRIPTION
Expands on @ShukantPal's work for `lite` mode.

* Change name from `lite` to `embed` (however, `lite` still works)
* Adds `noredirect` query param option to disable redirect button
* Adds `showcode` query param option to allow toggle code view
* Adds `autoplay` query param option to auto-load the current example (default is to click the refresh button)
* Fix the style of redirect button/icon

![Screen Shot 2021-06-10 at 9 01 15 PM](https://user-images.githubusercontent.com/864393/121629107-61eb0d00-ca2f-11eb-9661-f59b6d26a369.png)
