### PR TITLE
Tilemap example script url

### DIFF
--- a/examples/packages.json
+++ b/examples/packages.json
@@ -12,7 +12,7 @@
         "version": "1.1.3"
     },
     "@pixi/tilemap": {
-        "script": "/dist/pixi-tilemap.umd.js"
+        "script": "dist/pixi-tilemap.umd.js"
     },
     "pixi-filters": {
         "script": "/pixi-filters.js",


### PR DESCRIPTION
Regarding https://github.com/pixijs/pixijs/issues/8209 

From the PIxi examples page, the TILEMAPS -> Basic example fails to load.
https://pixijs.io/examples/?v=dev#/tilemaps/basic.js

Looks like the URL is invalid, with a double `//` to jsdelivr:

![image](https://user-images.githubusercontent.com/1213591/156701203-5fa4d217-4bab-478e-b130-472c9bc2df28.png)

It's trying to load: https://cdn.jsdelivr.net/npm/@pixi/tilemap@latest//dist/pixi-tilemap.umd.js

<img width="656" alt="image" src="https://user-images.githubusercontent.com/1213591/156701261-9c5720ef-0c76-4371-a7b7-366dcc1c441b.png">

Instead it should be: https://cdn.jsdelivr.net/npm/@pixi/tilemap@latest/dist/pixi-tilemap.umd.js

Demo fails to load.
<img width="838" alt="image" src="https://user-images.githubusercontent.com/1213591/156701391-88f76db5-3de7-46f7-a29c-59756d91b3ff.png">
