### PR TITLE
Add examples for OffscreenCanvas and Web Workers

### DIFF
--- a/public/examples/js/offscreen-canvas/basic.js
+++ b/public/examples/js/offscreen-canvas/basic.js
@@ -1,0 +1,45 @@
+// This example is the based on demos-basic/container, but using OffscreenCanvas.
+
+const width = 800;
+const height = 600;
+const resolution = window.devicePixelRatio;
+const canvas = document.createElement('canvas');
+canvas.style.width = `${width}px`;
+canvas.style.height = `${height}px`;
+document.body.appendChild(canvas);
+const view = canvas.transferControlToOffscreen();
+
+const app = new PIXI.Application({
+    width, height, resolution, view, backgroundColor: 0x1099bb,
+});
+
+const container = new PIXI.Container();
+
+app.stage.addChild(container);
+
+// Create a new texture
+const texture = PIXI.Texture.from('examples/assets/bunny.png');
+
+// Create a 5x5 grid of bunnies
+for (let i = 0; i < 25; i++) {
+    const bunny = new PIXI.Sprite(texture);
+    bunny.anchor.set(0.5);
+    bunny.x = (i % 5) * 40;
+    bunny.y = Math.floor(i / 5) * 40;
+    container.addChild(bunny);
+}
+
+// Move container to the center
+container.x = app.screen.width / 2;
+container.y = app.screen.height / 2;
+
+// Center bunny sprite in local container coordinates
+container.pivot.x = container.width / 2;
+container.pivot.y = container.height / 2;
+
+// Listen for animate update
+app.ticker.add((delta) => {
+    // rotate the container!
+    // use delta to create frame-independent transform
+    container.rotation -= 0.01 * delta;
+});

--- a/public/examples/js/offscreen-canvas/basic.js
+++ b/public/examples/js/offscreen-canvas/basic.js
@@ -1,17 +1,10 @@
 // This example is the based on demos-basic/container, but using OffscreenCanvas.
 
-const width = 800;
-const height = 600;
-const resolution = window.devicePixelRatio;
 const canvas = document.createElement('canvas');
-canvas.style.width = `${width}px`;
-canvas.style.height = `${height}px`;
 document.body.appendChild(canvas);
 const view = canvas.transferControlToOffscreen();
 
-const app = new PIXI.Application({
-    width, height, resolution, view, backgroundColor: 0x1099bb,
-});
+const app = new PIXI.Application({ view, background: 0x1099bb });
 
 const container = new PIXI.Container();
 

--- a/public/examples/js/offscreen-canvas/web-worker.js
+++ b/public/examples/js/offscreen-canvas/web-worker.js
@@ -1,0 +1,66 @@
+// This example is the based on demos-basic/container, but running in Web Worker.
+
+function workerSource(self) {
+    self.onmessage = async ({
+        data: { baseUrl, pixiWebWorkerUrl, options },
+    }) => {
+        self.importScripts(new URL(pixiWebWorkerUrl, baseUrl));
+
+        const app = new PIXI.Application(options);
+
+        const container = new PIXI.Container();
+
+        app.stage.addChild(container);
+
+        // Create a new texture
+        const textureUrl = new URL('examples/assets/bunny.png', baseUrl).toString();
+        const texture = PIXI.Texture.from(textureUrl);
+
+        // Create a 5x5 grid of bunnies
+        for (let i = 0; i < 25; i++) {
+            const bunny = new PIXI.Sprite(texture);
+            bunny.anchor.set(0.5);
+            bunny.x = (i % 5) * 40;
+            bunny.y = Math.floor(i / 5) * 40;
+            container.addChild(bunny);
+        }
+
+        // Move container to the center
+        container.x = app.screen.width / 2;
+        container.y = app.screen.height / 2;
+
+        // Center bunny sprite in local container coordinates
+        container.pivot.x = container.width / 2;
+        container.pivot.y = container.height / 2;
+
+        // Listen for animate update
+        app.ticker.add((delta) => {
+            // rotate the container!
+            // use delta to create frame-independent transform
+            container.rotation -= 0.01 * delta;
+        });
+    };
+}
+const blob = new Blob(['(', workerSource, ')(self);'], { type: 'application/javascript' });
+const url = URL.createObjectURL(blob);
+const worker = new Worker(url);
+URL.revokeObjectURL(url);
+
+const width = 800;
+const height = 600;
+const resolution = window.devicePixelRatio;
+const canvas = document.createElement('canvas');
+canvas.style.width = `${width}px`;
+canvas.style.height = `${height}px`;
+document.body.appendChild(canvas);
+const view = canvas.transferControlToOffscreen();
+
+const baseUrl = window.location.href;
+const pixiWebWorkerUrl = window.PIXI_WEBWORKER_URL;
+worker.postMessage({
+    baseUrl,
+    pixiWebWorkerUrl,
+    options: {
+        width, height, resolution, view, backgroundColor: 0x1099bb,
+    },
+}, [view]);

--- a/public/examples/js/offscreen-canvas/web-worker.js
+++ b/public/examples/js/offscreen-canvas/web-worker.js
@@ -61,6 +61,6 @@ worker.postMessage({
     baseUrl,
     pixiWebWorkerUrl,
     options: {
-        width, height, resolution, view, backgroundColor: 0x1099bb,
+        width, height, resolution, view, background: 0x1099bb,
     },
 }, [view]);

--- a/public/examples/manifest.json
+++ b/public/examples/manifest.json
@@ -229,11 +229,13 @@
         "title": "Offscreen Canvas",
 		"items": [{
 				"title": "Basic",
-				"entry": "basic.js"
+				"entry": "basic.js",
+				"features": ["OffscreenCanvas"]
 			},
 			{
 				"title": "Web Worker",
-				"entry": "web-worker.js"
+				"entry": "web-worker.js",
+				"features": ["OffscreenCanvas"]
 			}
 		]
 	},

--- a/public/examples/manifest.json
+++ b/public/examples/manifest.json
@@ -225,6 +225,19 @@
 		]
 	},
 	{
+        "id": "offscreen-canvas",
+        "title": "Offscreen Canvas",
+		"items": [{
+				"title": "Basic",
+				"entry": "basic.js"
+			},
+			{
+				"title": "Web Worker",
+				"entry": "web-worker.js"
+			}
+		]
+	},
+	{
         "id": "filters-basic",
         "title": "Filters - Basic",
 		"items": [{

--- a/src/main.js
+++ b/src/main.js
@@ -223,11 +223,14 @@ jQuery(document).ready(($) => {
 
             // Generate HTML and insert into iFrame
             let pixiUrl = '';
+            let pixiWebWorkerUrl = '';
 
             if (bpc.pixiVersionString === 'local') {
                 pixiUrl = 'dist/pixi.js';
+                pixiWebWorkerUrl = 'dist/webworker.js';
             } else { // other versions come from S3
                 pixiUrl = `https://d157l7jdn8e5sf.cloudfront.net/${bpc.pixiVersionString}/pixi-legacy.js`;
+                pixiWebWorkerUrl = `https://d157l7jdn8e5sf.cloudfront.net/${bpc.pixiVersionString}/webworker.js`;
             }
 
             let html = '<!DOCTYPE html><html><head><style>';
@@ -269,7 +272,7 @@ jQuery(document).ready(($) => {
 
             if (!bpc.exampleValidVersions.length || bpc.exampleValidVersions.indexOf(bpc.majorPixiVersion) > -1) {
                 $('#example-title').html(bpc.exampleTitle);
-                html += `<script>window.onload = function(){${bpc.exampleSourceCode}}</script></body></html>`;
+                html += `<script>window.PIXI_WEBWORKER_URL = "${pixiWebWorkerUrl}"; window.onload = function(){${bpc.exampleSourceCode}}</script></body></html>`;
 
                 $('.example-frame').show();
             } else {

--- a/src/main.js
+++ b/src/main.js
@@ -63,6 +63,10 @@ jQuery(document).ready(($) => {
     bpc.autoPlay = true;
     bpc.packagesManifest = {};
 
+    bpc.browserFeatures = {
+        OffscreenCanvas: typeof OffscreenCanvas === 'function',
+    };
+
     bpc.init = function init() {
         const embedded = bpc.embedMode();
 
@@ -71,7 +75,8 @@ jQuery(document).ready(($) => {
             items.filter((item) => item.visible !== false).forEach((item) => {
                 const plugins = typeof item.plugins !== 'undefined' ? item.plugins.join(',') : '';
                 const validVersions = typeof item.validVersions !== 'undefined' ? item.validVersions.join(',') : '';
-                html += `<li data-src="${item.entry}" data-plugins="${plugins}" data-validVersions="${validVersions}">${item.title}</li>`;
+                const features = typeof item.features !== 'undefined' ? item.features.join(',') : '';
+                html += `<li data-src="${item.entry}" data-plugins="${plugins}" data-validVersions="${validVersions}" data-features="${features}">${item.title}</li>`;
             });
             html += '</ul>';
             $('.main-menu').append(html);
@@ -190,6 +195,9 @@ jQuery(document).ready(($) => {
                 const validVersions = $(this).attr('data-validVersions');
                 bpc.exampleValidVersions = validVersions === '' ? [7] : validVersions.split(',').map((v) => parseInt(v, 10));
 
+                const features = $(this).attr('data-features');
+                bpc.exampleFeatures = features === '' ? [] : features.split(',');
+
                 $.ajax({
                     url: `examples/js/${$(this).parent().attr('data-section')}/${$(this).attr('data-src')}`,
                     dataType: 'text',
@@ -262,6 +270,8 @@ jQuery(document).ready(($) => {
                 }
             }
 
+            bpc.missingFeatures = bpc.exampleFeatures.filter((x) => !bpc.browserFeatures[x]);
+
             bpc.editor = CodeMirror.fromTextArea(document.getElementById('code'), bpc.editorOptions);
 
             if (bpc.exampleRequiredPlugins.length) {
@@ -270,24 +280,35 @@ jQuery(document).ready(($) => {
                 $('#code-header').text('Example Code');
             }
 
-            if (!bpc.exampleValidVersions.length || bpc.exampleValidVersions.indexOf(bpc.majorPixiVersion) > -1) {
+            if (bpc.exampleValidVersions.length && bpc.exampleValidVersions.indexOf(bpc.majorPixiVersion) === -1) {
+                $('#example-title').html(
+                    `${bpc.exampleTitle}`
+                    + '<br><br><br><br><br><br><br>'
+                    + 'The selected version of PixiJS does not work with this example.'
+                    + '<br><br>'
+                    + `Selected version: v${bpc.majorPixiVersion}`
+                    + '<br><br>'
+                    + `Required version: v${bpc.exampleValidVersions.toString()}`
+                    + '<br><br><br><br><br>',
+                );
+
+                $('.example-frame').hide();
+            } else if (bpc.missingFeatures.length) {
+                $('#example-title').html(
+                    `${bpc.exampleTitle}`
+                    + '<br><br><br><br><br><br><br>'
+                    + 'This example requires some features that your browser doesn\'t support.'
+                    + '<br><br>'
+                    + `Missing features: ${bpc.missingFeatures.join(', ')}`
+                    + '<br><br><br><br><br>',
+                );
+
+                $('.example-frame').hide();
+            } else {
                 $('#example-title').html(bpc.exampleTitle);
                 html += `<script>window.PIXI_WEBWORKER_URL = "${pixiWebWorkerUrl}"; window.onload = function(){${bpc.exampleSourceCode}}</script></body></html>`;
 
                 $('.example-frame').show();
-            } else {
-                $('#example-title').html(
-                    `${bpc.exampleTitle
-                    }<br><br><br><br><br><br><br>`
-                    + 'The selected version of PixiJS does not work with this example.'
-                    + '<br><br>'
-                    + `Selected version: v${bpc.majorPixiVersion
-                    }<br><br>`
-                    + `Required version: v${bpc.exampleValidVersions.toString()
-                    }<br><br><br><br><br>`,
-                );
-
-                $('.example-frame').hide();
             }
 
             const iframe = document.getElementById('preview');


### PR DESCRIPTION
Add examples `offscreen-canvas/basic` and `offscreen-canvas/web-worker` to illustrate usage of Pixi.js for OffscreenCanvas and Web Workers.

See also https://github.com/pixijs/pixijs/pull/8698.

##### Todo List

- [x] Add CDN URL for `@pixi/webworker`
